### PR TITLE
BUGFIX: Avoid error in anyOf when sub-protypes exist that have no editor

### DIFF
--- a/Classes/PropTypesToEditorConverterFacade.php
+++ b/Classes/PropTypesToEditorConverterFacade.php
@@ -73,11 +73,13 @@ final class PropTypesToEditorConverterFacade implements ProtectedContextAwareInt
     }
 
     /**
-     * @param EditorContainer ...$editorContainers
+     * @param null|EditorContainer ...$editorContainers
      * @return null|EditorContainer
      */
-    public function anyOf(EditorContainer ...$editorContainers): ?EditorContainer
+    public function anyOf(?EditorContainer ...$editorContainers): ?EditorContainer
     {
+        $editorContainers = array_filter($editorContainers);
+
         if (isset($editorContainers[0])) {
             return $editorContainers[0];
         }


### PR DESCRIPTION
Resolves: https://github.com/sitegeist/Sitegeist.Monocle.PropTypes/issues/1